### PR TITLE
fix font family mangling and clipboard hijacking

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -56,12 +56,10 @@ function activate(context) {
     
     const selectionHandler = vscode.window.onDidChangeTextEditorSelection(e => {
       if (e.selections[0] && !e.selections[0].isEmpty) {
-        if (e.selections[0] && !e.selections[0].isEmpty) {
-          vscode.commands.executeCommand('editor.action.clipboardCopyAction')
-          panel.webview.postMessage({
-            type: 'update'
-          })
-        }
+        vscode.commands.executeCommand('editor.action.clipboardCopyAction')
+        panel.webview.postMessage({
+          type: 'update'
+        })
       }
     })
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -53,6 +53,19 @@ function activate(context) {
       enableScripts: true,
       localResourceRoots: [vscode.Uri.file(path.join(context.extensionPath, 'webview'))]
     })
+    
+    const selectionHandler = vscode.window.onDidChangeTextEditorSelection(e => {
+      if (e.selections[0] && !e.selections[0].isEmpty) {
+        if (e.selections[0] && !e.selections[0].isEmpty) {
+          vscode.commands.executeCommand('editor.action.clipboardCopyAction')
+          panel.webview.postMessage({
+            type: 'update'
+          })
+        }
+      }
+    })
+
+    panel.onDidDispose(() => selectionHandler.dispose())
 
     panelHandlers()
 
@@ -75,17 +88,6 @@ function activate(context) {
       fontFamily,
       bgColor
     })
-  })
-
-  vscode.window.onDidChangeTextEditorSelection(e => {
-    if (e.selections[0] && !e.selections[0].isEmpty) {
-      // TODO: Redo from use clipboard to another way
-      // let editor = vscode.window.activeTextEditor
-      // const texxt = editor.document.getText(editor.selection)
-
-      vscode.commands.executeCommand('editor.action.clipboardCopyAction')
-      panel.webview.postMessage({ type: 'update' })
-    }
   })
 }
 
@@ -229,7 +231,7 @@ function getHTML(indexJS, vivusJS, dom2imageJS) {
             <span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span
             ><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span
             ><span style="color: #eceff4;">'</span
-            ><span style="color: #a3be8c;">0. Run command \`Polacode ?“¸ \`</span
+            ><span style="color: #a3be8c;">0. Run command \`Polacode ?â€œÂ¸ \`</span
             ><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span>
           </div>
           <div>
@@ -248,7 +250,7 @@ function getHTML(indexJS, vivusJS, dom2imageJS) {
           <div>
             <span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span
             ><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span
-            ><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">3. Click the button ?“¸ </span
+            ><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">3. Click the button ?â€œÂ¸ </span
             ><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span>
           </div>
         </div>

--- a/webview/index.js
+++ b/webview/index.js
@@ -56,7 +56,9 @@
     return getBrightness(hexColor) < 128
   }
   function getSnippetBgColor(html) {
-    return html.match(/background-color: (#[a-fA-F0-9]+)/)[1]
+    const div = document.createElement('div')
+    div.innerHTML = html
+    return div.querySelector('div').style.backgroundColor
   }
 
   function updateEnvironment(snippetBgColor) {

--- a/webview/index.js
+++ b/webview/index.js
@@ -7,10 +7,12 @@
   const shadowsOption = document.getElementById('optShadows')
   const transparentOption = document.getElementById('optTransparent')
   const colorOption = document.getElementById('optColor')
+  let fontFamily
 
-  const getInitialHtml = fontFamily => {
+  const getInitialHtml = ff => {
     const cameraWithFlashEmoji = String.fromCodePoint(128248)
-    const monoFontStack = `${fontFamily},SFMono-Regular,Consolas,DejaVu Sans Mono,Ubuntu Mono,Liberation Mono,Menlo,Courier,monospace`
+    const monoFontStack = `${ff},SFMono-Regular,Consolas,DejaVu Sans Mono,Ubuntu Mono,Liberation Mono,Menlo,Courier,monospace`
+    fontFamily = monoFontStack
     return `<meta charset="utf-8"><div style="color: #d8dee9;background-color: #2e3440; font-family: ${monoFontStack};font-weight: normal;font-size: 12px;line-height: 18px;white-space: pre;"><div><span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">0. Run command \`Polacode ${cameraWithFlashEmoji}\`</span><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span></div><div><span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">1. Copy some code</span><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span></div><div><span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">2. Paste into Polacode view</span><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span></div><div><span style="color: #8fbcbb;">console</span><span style="color: #eceff4;">.</span><span style="color: #88c0d0;">log</span><span style="color: #d8dee9;">(</span><span style="color: #eceff4;">'</span><span style="color: #a3be8c;">3. Click the button ${cameraWithFlashEmoji}</span><span style="color: #eceff4;">'</span><span style="color: #d8dee9;">)</span></div></div></div>`
   }
 
@@ -108,10 +110,12 @@
   }
 
   document.addEventListener('paste', e => {
-    const innerHTML = e.clipboardData.getData('text/html')
+    const div = document.createElement('div')
+    div.innerHTML = e.clipboardData.getData('text/html')
+    div.querySelector('div').style.fontFamily = fontFamily
     const code = e.clipboardData.getData('text/plain')
 
-    updateCode(innerHTML, code)
+    updateCode(div.innerHTML, code)
   })
 
   shadowsOption.addEventListener('change', () => {


### PR DESCRIPTION
I made this PR on the parent branch but I'm not confident it'll ever get merged.

`e.clipboard.getData('text/html')` mangles the font family for some reason. This fixes it. This also fixes the clipboard being hijacked even after the panel has been closed.